### PR TITLE
Networked lobby

### DIFF
--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -20,6 +20,9 @@ GameObject:
   - component: {fileID: 4234837731021330579}
   - component: {fileID: 7444753961910310332}
   - component: {fileID: 3189841601692809775}
+  - component: {fileID: 2587163288284336422}
+  - component: {fileID: 7630974732043695949}
+  - component: {fileID: 8228536620802389943}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -59,24 +62,20 @@ MonoBehaviour:
     name: Pink
   - color: {r: 0.014705896, g: 0.9184584, b: 1, a: 1}
     name: Blue
-  matchLength: 99999
   meta: {fileID: 0}
-  pauseAfterGoalScore: 3
-  pauseAfterReset: 2
   players: []
   gameSettings:
     PushAwayOtherPlayers: 1
     SlowMoFactor: 0.4
     PitchShiftTime: 0.3
     SlowedPitch: 0.5
-    GoalShakeAmount: 1.5
-    GoalShakeDuration: 0.4
     RespectSoundEffectSlowMo: 1
     WinningScore: 4
     RequiredWinMargin: 1
+    PauseAfterGoalScore: 3
+    LengthOfBallSpawnAnimation: 2
   blowbackPrefab: {fileID: 1010691673323716, guid: 5a5eb56d9336c4c23906a3b6aad98b9a,
     type: 3}
-  winCondition: 2
 --- !u!114 &114211205889215070
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -112,7 +111,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1217675377384306}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 08f7fb940a3a942dd8739912240d2198, type: 3}
   m_Name: 
@@ -217,3 +216,41 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   stealShakeAmount: 0.7
   stealShakeDuration: 0.05
+  GoalShakeAmount: 1.5
+  GoalShakeDuration: 0.4
+--- !u!114 &2587163288284336422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217675377384306}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f4379ef8320643b8ad7b8d32f139f83, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7630974732043695949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217675377384306}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5db7da1130502406ab691886a66549bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8228536620802389943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217675377384306}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d509d0fe8a05844eda7bd3b705cbc477, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/InControl.prefab
+++ b/Assets/Prefabs/InControl.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1135404277077178}
-  m_IsPrefabParent: 1
 --- !u!1 &1135404277077178
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4084747828176844}
   - component: {fileID: 114064714965038402}
@@ -29,9 +19,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4084747828176844
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1135404277077178}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -42,9 +33,10 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114064714965038402
 MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1135404277077178}
   m_Enabled: 1
   m_EditorHideFlags: 0

--- a/Assets/Prefabs/SpawnPoint.prefab
+++ b/Assets/Prefabs/SpawnPoint.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &813334746742545517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4080437710676593902}
+  - component: {fileID: 885492724510561715}
+  m_Layer: 0
+  m_Name: SpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4080437710676593902
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 813334746742545517}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 18.261824, y: 26.277063, z: -0.44101012}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &885492724510561715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 813334746742545517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68853aae7b4eb4400a9e3aac0639e66b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/SpawnPoint.prefab.meta
+++ b/Assets/Prefabs/SpawnPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86e8f55c20d654b5a96f40379e0d9f21
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Player.prefab
+++ b/Assets/Resources/Player.prefab
@@ -563,8 +563,8 @@ MonoBehaviour:
   ObservedComponents:
   - {fileID: 440}
   - {fileID: 439}
-  viewIdField: 0
-  InstantiationId: 7
+  viewIdField: 1
+  InstantiationId: 1
   isRuntimeInstantiated: 0
 --- !u!114 &440
 MonoBehaviour:

--- a/Assets/Resources/Player.prefab
+++ b/Assets/Resources/Player.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1233221201083302
+--- !u!1 &262
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,29 +8,29 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4866693309565106}
-  - component: {fileID: 212918527776535888}
-  - component: {fileID: 60192982943300094}
-  - component: {fileID: 50968593018913712}
-  - component: {fileID: 114205997563975182}
-  - component: {fileID: 114215232534320030}
-  - component: {fileID: 61713479168382808}
-  - component: {fileID: 114130524022212122}
-  - component: {fileID: 114319027261209328}
-  - component: {fileID: 114631768565738774}
-  - component: {fileID: 114920135743144974}
-  - component: {fileID: 114694489525978138}
-  - component: {fileID: 114261427851223390}
-  - component: {fileID: 114319664088283476}
-  - component: {fileID: 120631931489294666}
-  - component: {fileID: 114759646302619538}
-  - component: {fileID: 114885571489087022}
-  - component: {fileID: 114738638914321764}
-  - component: {fileID: 114740959938619730}
-  - component: {fileID: 114512497374375228}
-  - component: {fileID: 114024204710271916}
-  - component: {fileID: 4699721130647362219}
-  - component: {fileID: 1579188638025929307}
+  - component: {fileID: 306}
+  - component: {fileID: 406}
+  - component: {fileID: 344}
+  - component: {fileID: 342}
+  - component: {fileID: 427}
+  - component: {fileID: 428}
+  - component: {fileID: 345}
+  - component: {fileID: 426}
+  - component: {fileID: 430}
+  - component: {fileID: 433}
+  - component: {fileID: 439}
+  - component: {fileID: 434}
+  - component: {fileID: 429}
+  - component: {fileID: 431}
+  - component: {fileID: 347}
+  - component: {fileID: 437}
+  - component: {fileID: 438}
+  - component: {fileID: 435}
+  - component: {fileID: 436}
+  - component: {fileID: 432}
+  - component: {fileID: 425}
+  - component: {fileID: 441}
+  - component: {fileID: 440}
   m_Layer: 8
   m_Name: Player
   m_TagString: Untagged
@@ -38,27 +38,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4866693309565106
+--- !u!4 &306
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_LocalRotation: {x: 0, y: 0, z: -0.17364825, w: 0.9848078}
   m_LocalPosition: {x: -14, y: 38, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 3.75, y: 3.75, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -20}
---- !u!212 &212918527776535888
+--- !u!212 &406
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -100,13 +100,13 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!60 &60192982943300094
+--- !u!60 &344
 PolygonCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 6200000, guid: 573ea0f788bbe3844bb61fda4c693af3, type: 2}
@@ -129,14 +129,14 @@ PolygonCollider2D:
       - {x: 0.4615175, y: 0.008880369}
       - {x: -0.44731173, y: -0.41481206}
       - {x: -0.346112, y: 0.00090651517}
---- !u!50 &50968593018913712
+--- !u!50 &342
 Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -150,13 +150,13 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 4
---- !u!114 &114205997563975182
+--- !u!114 &427
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7bbe1fa63243a2c4cbd0e785d0c0fca9, type: 3}
@@ -172,13 +172,13 @@ MonoBehaviour:
   aimAssistEpsilon: 3.5
   aimAssistLerpStrength: 0.2
   minBallForceRotationTime: 0.1
---- !u!114 &114215232534320030
+--- !u!114 &428
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0847243840536f544ba8cd8206b47c60, type: 3}
@@ -188,13 +188,13 @@ MonoBehaviour:
   teamOverride: -1
   initialPosition: {x: 0, y: 0}
   initialRotation: 0
---- !u!61 &61713479168382808
+--- !u!61 &345
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
@@ -214,13 +214,13 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 0.8}
   m_EdgeRadius: 0
---- !u!114 &114130524022212122
+--- !u!114 &426
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 97ed3cd97c2f14d5789fd90f0a8a7e22, type: 3}
@@ -241,13 +241,13 @@ MonoBehaviour:
   stealKnockbackAmount: 100
   stealKnockbackLength: 0.4
   wallHitStunTime: 0.05
---- !u!114 &114319027261209328
+--- !u!114 &430
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 964e4864ae7674458906684fac594544, type: 3}
@@ -281,13 +281,13 @@ MonoBehaviour:
   maxShotSpeed: 195
   maxChargeShotTime: 1.5
   forcedShotTime: 3.75
---- !u!114 &114631768565738774
+--- !u!114 &433
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4abcea3fd45d64d389967783e181b42f, type: 3}
@@ -300,25 +300,25 @@ MonoBehaviour:
     type: 3}
   coolDownTime: 0.1
   slowMoOnCarry: 1
---- !u!114 &114920135743144974
+--- !u!114 &439
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1b46c230ed06b43dbb065352c75f1577, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114694489525978138
+--- !u!114 &434
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d4e43ea7dfcf541a7b0afdd2de3ab3be, type: 3}
@@ -331,38 +331,38 @@ MonoBehaviour:
   parentEffectToPlayer: 1
   destroyWait: 0
   effectType: 0
---- !u!114 &114261427851223390
+--- !u!114 &429
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3e2c5e274b6fb4d5cb730d55a0aceb4c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114319664088283476
+--- !u!114 &431
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 209e8991cf01b419ebe9573ca024c9ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   stunFlashInterval: 0.1
---- !u!120 &120631931489294666
+--- !u!120 &347
 LineRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -449,13 +449,13 @@ LineRenderer:
     generateLightingData: 0
   m_UseWorldSpace: 1
   m_Loop: 0
---- !u!114 &114759646302619538
+--- !u!114 &437
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc9d5c77132154d129f38ef058cda5ea, type: 3}
@@ -463,13 +463,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   drawDistanceAfterCollision: 30
   epsilon: 0.02
---- !u!114 &114885571489087022
+--- !u!114 &438
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b31f31e3cae45443eb82857cd992377a, type: 3}
@@ -484,25 +484,25 @@ MonoBehaviour:
   wallLimit: 2
   wallLayingDurationCap: 1
   wallBreakSoundVolume: 0.35
---- !u!114 &114738638914321764
+--- !u!114 &435
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 82f70eb28cc9e49b7ac4d508acd1bb7c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114740959938619730
+--- !u!114 &436
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3215b35537cbded4eaf07d50253cf7d6, type: 3}
@@ -514,13 +514,13 @@ MonoBehaviour:
   gameWinRumbleDuration: 1
   layingWallStunDuration: 0.5
   ballPossessionRumbleDuration: 0.15
---- !u!114 &114512497374375228
+--- !u!114 &432
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0328f7b239f604ceb8d194a232551eb5, type: 3}
@@ -531,25 +531,25 @@ MonoBehaviour:
     type: 3}
   timeBetweenGhosts: 0.02
   startingAlpha: 0.5
---- !u!114 &114024204710271916
+--- !u!114 &425
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9c03117bab1e3455f948c1114ce3f9b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4699721130647362219
+--- !u!114 &441
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
@@ -561,18 +561,18 @@ MonoBehaviour:
   Synchronization: 3
   OwnershipTransfer: 1
   ObservedComponents:
-  - {fileID: 1579188638025929307}
-  - {fileID: 114920135743144974}
+  - {fileID: 440}
+  - {fileID: 439}
   viewIdField: 0
   InstantiationId: 7
   isRuntimeInstantiated: 0
---- !u!114 &1579188638025929307
+--- !u!114 &440
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1233221201083302}
+  m_GameObject: {fileID: 262}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 38e6157188c939a468fe905350efc1d1, type: 3}

--- a/Assets/Scenes/court-networked-lobby.unity
+++ b/Assets/Scenes/court-networked-lobby.unity
@@ -175,351 +175,111 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 3324306}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &75275703
+--- !u!1001 &95293854
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1188379735}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 27
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4084747828176844, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
       propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1135404277077178, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
+      propertyPath: m_Name
+      value: InControl
+      objectReference: {fileID: 0}
+    - target: {fileID: 114064714965038402, guid: 123bb987f60e24253a9f72eef5f3801a,
+        type: 3}
+      propertyPath: dontDestroyOnLoad
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point4Indicator
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 123bb987f60e24253a9f72eef5f3801a, type: 3}
 --- !u!4 &104172858 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da,
     type: 3}
   m_PrefabInstance: {fileID: 738967300}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &156508575
+--- !u!1001 &145649959
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 27.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.92387956
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.38268343
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -135
-      objectReference: {fileID: 0}
-    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_Name
-      value: SpawnPoint1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: SpawnPointNumber
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
---- !u!1001 &164290748
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1188379735}
-    m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -27
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point1Indicator
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!4 &164290749 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 164290748}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &176022096
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 176022097}
-  - component: {fileID: 176022099}
-  - component: {fileID: 176022098}
-  m_Layer: 0
-  m_Name: MetaControlsPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &176022097
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 176022096}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 687356461}
-  m_Father: {fileID: 2082202136}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.18}
-  m_AnchorMax: {x: 0.5, y: 0.28}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 0}
-  m_Pivot: {x: 0.5, y: 0.23}
---- !u!114 &176022098
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 176022096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &176022099
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 176022096}
-  m_CullTransparentMesh: 0
---- !u!1001 &197524633
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.92387956
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.38268343
+      value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
+    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
       propertyPath: m_RootOrder
-      value: 14
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 135
-      objectReference: {fileID: 0}
-    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_Name
-      value: SpawnPoint4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: SpawnPointNumber
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 1319945779, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+      propertyPath: viewIdField
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1319945779, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+      propertyPath: InstantiationId
+      value: 5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
 --- !u!1 &198209132
 GameObject:
   m_ObjectHideFlags: 0
@@ -531,7 +291,6 @@ GameObject:
   - component: {fileID: 198209133}
   - component: {fileID: 198209135}
   - component: {fileID: 198209134}
-  - component: {fileID: 198209136}
   m_Layer: 0
   m_Name: PausedText
   m_TagString: Untagged
@@ -553,11 +312,11 @@ RectTransform:
   m_Father: {fileID: 2082202136}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.66}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 18}
-  m_SizeDelta: {x: 0, y: -35}
-  m_Pivot: {x: 0.5, y: 0.2}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.03}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &198209134
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -571,7 +330,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.78891987, g: 0.86989546, b: 0.9338235, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -580,12 +339,12 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 134
+    m_FontSize: 64
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 273
-    m_Alignment: 7
+    m_MinSize: 2
+    m_MaxSize: 64
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 1
@@ -599,109 +358,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 198209132}
-  m_CullTransparentMesh: 0
---- !u!114 &198209136
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198209132}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -900027084, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
-  m_EffectDistance: {x: 1, y: -1}
-  m_UseGraphicAlpha: 1
---- !u!1 &240401211
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 240401212}
-  - component: {fileID: 240401215}
-  - component: {fileID: 240401214}
-  - component: {fileID: 240401213}
-  m_Layer: 0
-  m_Name: JustInTime
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &240401212
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 240401211}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1}
-  m_LocalScale: {x: 0.99444157, y: 0.99444157, z: 0.99444157}
-  m_Children:
-  - {fileID: 1654796401}
-  m_Father: {fileID: 1335570559}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000061035156, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &240401213
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 240401211}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 464f92ea63cf74df6b629e983196a6e6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &240401214
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 240401211}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &240401215
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 240401211}
   m_CullTransparentMesh: 0
 --- !u!1001 &244845673
 PrefabInstance:
@@ -773,10 +429,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SortingLayer
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
-      propertyPath: m_Layer
-      value: 17
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
@@ -853,96 +505,239 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 253386683}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &256258894 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 75275703}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &322891667
-PrefabInstance:
+--- !u!1 &276001308
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.38268343
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.92387956
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 45
-      objectReference: {fileID: 0}
-    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_Name
-      value: SpawnPoint3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.x
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 276001309}
+  - component: {fileID: 276001312}
+  - component: {fileID: 276001311}
+  - component: {fileID: 276001310}
+  m_Layer: 5
+  m_Name: InCourtCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &276001309
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 276001308}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1796129066}
+  m_Father: {fileID: 1229941009}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 128, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &276001310
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 276001308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &276001311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 276001308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 100
+--- !u!223 &276001312
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 276001308}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 25
+  m_TargetDisplay: 0
+--- !u!1 &312273607
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 312273608}
+  - component: {fileID: 312273610}
+  - component: {fileID: 312273611}
+  - component: {fileID: 312273612}
+  m_Layer: 0
+  m_Name: SkipText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &312273608
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312273607}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9999984, y: 0.9999984, z: 0.9999984}
+  m_Children: []
+  m_Father: {fileID: 1796129066}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 11.28}
+  m_SizeDelta: {x: 128, y: 4.04}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &312273610
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312273607}
+  m_CullTransparentMesh: 0
+--- !u!114 &312273611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312273607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3628126b696db4a939ebfd566a2621c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  period: 1
+  lerpFontSize: 0
+  minRectScale: 1
+  maxRectScale: 1.15
+  fontSizeCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.y
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1.15
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  lerpColor: 1
+  startColor: {r: 0.778, g: 0.778, b: 0.778, a: 0.75686276}
+  endColor: {r: 0.8392157, g: 0.8392157, b: 0.8392157, a: 0.24705882}
+  colorCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: SpawnPointNumber
-      value: 3
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+--- !u!114 &312273612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312273607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83f6c6be0b17d4b5693782a205a1eda1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fontSize: 3
+  initialSpacing: 0
+  elementSpacing: 1
+  imageVerticalSpacing: 0.03
+  center: 1
+  textColor: {r: 0.8392157, g: 0.8392157, b: 0.8392157, a: 1}
+  textPrefabName: RichTextPrefabs/RichElementText
+  imagePrefabName: RichTextPrefabs/RichElementImage
+  initialContent: 
 --- !u!1001 &376848144
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1042,41 +837,10 @@ Transform:
   - {fileID: 3324307}
   - {fileID: 376848145}
   - {fileID: 864316199}
+  - {fileID: 1037426596}
   m_Father: {fileID: 1229941009}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &436276102 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 244845673}
-  m_PrefabAsset: {fileID: 0}
---- !u!61 &436276103
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 436276102}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
 --- !u!1001 &439086875
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1148,10 +912,6 @@ PrefabInstance:
       propertyPath: m_SortingLayer
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
 --- !u!4 &439086876 stripped
@@ -1170,8 +930,7 @@ GameObject:
   m_Component:
   - component: {fileID: 439142900}
   - component: {fileID: 439142901}
-  - component: {fileID: 439142902}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CornerCircle2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1240,22 +999,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &439142902
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 439142899}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.5
 --- !u!1 &441383114
 GameObject:
   m_ObjectHideFlags: 0
@@ -1335,130 +1078,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 441383114}
   m_CullTransparentMesh: 0
---- !u!1001 &473524556
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 543230446}
-    m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point3Indicator
-      objectReference: {fileID: 0}
-    - target: {fileID: 212140191465685248, guid: 4ece140ee1e6d418eacea6a6d609f489,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 212218223913872978, guid: 4ece140ee1e6d418eacea6a6d609f489,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: stops.Array.data[0].a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: stops.Array.data[1].a
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!4 &473524557 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 473524556}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &479130578
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1229941009}
-    m_Modifications:
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -26.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 198000717990533238, guid: e52e78f4f7ff34ea4b521c3212c59269,
-        type: 3}
-      propertyPath: looping
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 198000717990533238, guid: e52e78f4f7ff34ea4b521c3212c59269,
-        type: 3}
-      propertyPath: playOnAwake
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4287000190746736, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.05
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e52e78f4f7ff34ea4b521c3212c59269, type: 3}
 --- !u!1 &497832505
 GameObject:
   m_ObjectHideFlags: 0
@@ -1473,8 +1092,7 @@ GameObject:
   - component: {fileID: 497832507}
   - component: {fileID: 497832506}
   - component: {fileID: 497832511}
-  - component: {fileID: 497832513}
-  - component: {fileID: 497832514}
+  - component: {fileID: 497832512}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -1538,7 +1156,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 50
+  orthographic size: 45
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -1581,7 +1199,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   profile: {fileID: 11400000, guid: 1a5f9e5ce3c294ff7849bc0938f7228f, type: 2}
---- !u!114 &497832513
+--- !u!114 &497832512
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1590,25 +1208,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 497832505}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 123cbf2a716274329987527eeae7d217, type: 3}
+  m_Script: {fileID: 11500000, guid: e52b37546de6d4bc5833aa5d9794b6f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &497832514
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 497832505}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8912f3c8af4a14e898963ab9d5654e12, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  chromaticAberrationController: {fileID: 0}
-  aberationMagnitude: 0.5
-  transitionTime: 0.1
---- !u!1 &543230444
+--- !u!1 &514595436
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1616,53 +1219,93 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 543230446}
-  - component: {fileID: 543230445}
+  - component: {fileID: 514595437}
+  - component: {fileID: 514595440}
+  - component: {fileID: 514595439}
+  - component: {fileID: 514595438}
   m_Layer: 0
-  m_Name: PinkScoreIndicator
+  m_Name: LoserText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &543230445
+--- !u!224 &514595437
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 514595436}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9999973, y: 0.9999973, z: 0.9999973}
+  m_Children: []
+  m_Father: {fileID: 900835211}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -71.9}
+  m_SizeDelta: {x: 373.1, y: 46.6}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &514595438
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 543230444}
+  m_GameObject: {fileID: 514595436}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e5b0acf0fac824429a270aefa780a367, type: 3}
+  m_Script: {fileID: -900027084, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  teamName: Pink
-  stops:
-  - {r: 0, g: 0, b: 0, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
-  - {r: 0.92475796, g: 0.33088237, b: 1, a: 1}
-  durations:
-  - 0.3
-  - 1
---- !u!4 &543230446
-Transform:
+  m_EffectColor: {r: 0.1397059, g: 0.1397059, b: 0.1397059, a: 0.5}
+  m_EffectDistance: {x: 2, y: -2}
+  m_UseGraphicAlpha: 1
+--- !u!114 &514595439
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 543230444}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 70, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 941020978}
-  - {fileID: 473524557}
-  - {fileID: 949926938}
-  - {fileID: 899284517}
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 514595436}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.88235295, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Ice team lost...
+--- !u!222 &514595440
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 514595436}
+  m_CullTransparentMesh: 0
 --- !u!1 &563911782
 GameObject:
   m_ObjectHideFlags: 0
@@ -1697,7 +1340,6 @@ RectTransform:
   - {fileID: 2082202136}
   - {fileID: 1708146074}
   - {fileID: 900835211}
-  - {fileID: 1995125425}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1755,7 +1397,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
-  m_Camera: {fileID: 497832509}
+  m_Camera: {fileID: 0}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -1764,41 +1406,9 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 100
+  m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &577386389 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 1891255964}
-  m_PrefabAsset: {fileID: 0}
---- !u!61 &577386390
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 577386389}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!1 &611976303
+--- !u!1 &589976234
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1806,49 +1416,49 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 611976304}
-  - component: {fileID: 611976306}
-  - component: {fileID: 611976305}
+  - component: {fileID: 589976235}
+  - component: {fileID: 589976237}
+  - component: {fileID: 589976236}
   m_Layer: 0
-  m_Name: ResetInstructions
+  m_Name: TeamSelectionLineTwo
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &611976304
+--- !u!224 &589976235
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 611976303}
+  m_GameObject: {fileID: 589976234}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.9999984, y: 0.9999984, z: 0.9999984}
   m_Children: []
-  m_Father: {fileID: 1658217951}
-  m_RootOrder: 0
+  m_Father: {fileID: 1796129066}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -102.334656}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &611976305
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -8.75}
+  m_SizeDelta: {x: 124, y: 4.39}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &589976236
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 611976303}
+  m_GameObject: {fileID: 589976234}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.8392157, g: 0.8392157, b: 0.8392157, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1857,136 +1467,25 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 32
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 'D-Pad UP:     main menu'
---- !u!222 &611976306
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 611976303}
-  m_CullTransparentMesh: 0
---- !u!1 &655543179 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 439086875}
-  m_PrefabAsset: {fileID: 0}
---- !u!61 &655543180
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 655543179}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!1 &682600853
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 682600854}
-  - component: {fileID: 682600856}
-  - component: {fileID: 682600855}
-  m_Layer: 0
-  m_Name: AButtonText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &682600854
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 682600853}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1908593143}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.3, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &682600855
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 682600853}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.3921569, g: 0.9921569, b: 0.30588236, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 60
+    m_FontSize: 20
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 0
-    m_MaxSize: 100
-    m_Alignment: 3
-    m_AlignByGeometry: 1
+    m_MaxSize: 150
+    m_Alignment: 4
+    m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Dash / Shoot
---- !u!222 &682600856
+  m_Text: DASH at A color TO pick a TEAM
+--- !u!222 &589976237
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 682600853}
+  m_GameObject: {fileID: 589976234}
   m_CullTransparentMesh: 0
 --- !u!1 &687356460
 GameObject:
@@ -2013,16 +1512,16 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 687356460}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 176022097}
-  m_RootOrder: 0
+  m_Father: {fileID: 2082202136}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000027358532, y: 0}
+  m_AnchoredPosition: {x: 0, y: -100}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &687356462
@@ -2058,7 +1557,9 @@ MonoBehaviour:
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: "Main Menu:       D-Pad UP    \nReset Scene:     D-Pad DOWN"
+  m_Text: 'Main Menu: D-Pad UP
+
+    Reset Scene: D-Pad DOWN'
 --- !u!222 &687356463
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2282,156 +1783,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1368724302}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &782831855
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 782831856}
-  - component: {fileID: 782831858}
-  - component: {fileID: 782831857}
-  m_Layer: 0
-  m_Name: AButtonImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &782831856
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 782831855}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.79999995, y: 0.79999995, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1908593143}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0.3, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.15, y: 0.5}
---- !u!114 &782831857
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 782831855}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 325dfed60644c4dd7bffc8dafdb8d441, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &782831858
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 782831855}
-  m_CullTransparentMesh: 0
---- !u!1 &786289545
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 786289546}
-  - component: {fileID: 786289548}
-  - component: {fileID: 786289547}
-  m_Layer: 0
-  m_Name: BButtonPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &786289546
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 786289545}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1423437611}
-  - {fileID: 866563268}
-  m_Father: {fileID: 1487263836}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.25}
---- !u!114 &786289547
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 786289545}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &786289548
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 786289545}
-  m_CullTransparentMesh: 0
 --- !u!1 &803571607
 GameObject:
   m_ObjectHideFlags: 0
@@ -2443,6 +1794,7 @@ GameObject:
   - component: {fileID: 803571608}
   - component: {fileID: 803571610}
   - component: {fileID: 803571609}
+  - component: {fileID: 803571611}
   m_Layer: 0
   m_Name: RestartText
   m_TagString: Untagged
@@ -2462,11 +1814,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 900835211}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 400}
+  m_AnchoredPosition: {x: 0, y: 250}
   m_SizeDelta: {x: 500, y: 90}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &803571609
@@ -2482,7 +1834,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.78891987, g: 0.86989546, b: 0.9338235, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2491,18 +1843,18 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 40
+    m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 1
-    m_MinSize: 4
+    m_MinSize: 10
     m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Resetting in: '
+  m_Text: restarting in 5
 --- !u!222 &803571610
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2511,6 +1863,21 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 803571607}
   m_CullTransparentMesh: 0
+--- !u!114 &803571611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803571607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.11764705, g: 0.11764705, b: 0.11764705, a: 0.5}
+  m_EffectDistance: {x: 2, y: -2}
+  m_UseGraphicAlpha: 1
 --- !u!1 &806270889
 GameObject:
   m_ObjectHideFlags: 0
@@ -2521,8 +1888,7 @@ GameObject:
   m_Component:
   - component: {fileID: 806270890}
   - component: {fileID: 806270891}
-  - component: {fileID: 806270892}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CornerCircle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2591,23 +1957,7 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &806270892
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 806270889}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.5
---- !u!1 &815884903
+--- !u!1 &809415598
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2615,77 +1965,161 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 815884904}
-  - component: {fileID: 815884907}
-  - component: {fileID: 815884906}
+  - component: {fileID: 809415599}
+  - component: {fileID: 809415600}
   m_Layer: 0
-  m_Name: RestartCount
+  m_Name: GoalBackground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &815884904
-RectTransform:
+--- !u!4 &809415599
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 815884903}
+  m_GameObject: {fileID: 809415598}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000024, y: 1.0000024, z: 1.0000024}
+  m_LocalScale: {x: 1, y: 1, z: 0}
   m_Children: []
-  m_Father: {fileID: 900835211}
-  m_RootOrder: 2
+  m_Father: {fileID: 1299703921}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 400}
-  m_SizeDelta: {x: 500, y: 90}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!114 &815884906
-MonoBehaviour:
+--- !u!212 &809415600
+SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 815884903}
+  m_GameObject: {fileID: 809415598}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: 0205ae774426e4dff84b94167d37e8c0, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 40
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 4
-    m_MaxSize: 40
-    m_Alignment: 5
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &815884907
-CanvasRenderer:
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1001 &827035612
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 815884903}
-  m_CullTransparentMesh: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.92387956
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.38268343
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 135
+      objectReference: {fileID: 0}
+    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: SpawnPointNumber
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
 --- !u!1001 &857941354
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2757,10 +2191,6 @@ PrefabInstance:
       propertyPath: m_SortingLayer
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
 --- !u!4 &857941355 stripped
@@ -2828,85 +2258,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 864316198}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &866563267
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 866563268}
-  - component: {fileID: 866563270}
-  - component: {fileID: 866563269}
-  m_Layer: 0
-  m_Name: BButtonText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &866563268
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 866563267}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 786289546}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.3, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000045776367, y: -0.0000076293945}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.4}
---- !u!114 &866563269
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 866563267}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.9333334, g: 0.24705884, b: 0.27058825, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 60
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 300
-    m_Alignment: 3
-    m_AlignByGeometry: 1
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Lay Wall
---- !u!222 &866563270
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 866563267}
-  m_CullTransparentMesh: 0
 --- !u!1 &868277037
 GameObject:
   m_ObjectHideFlags: 0
@@ -2934,7 +2285,7 @@ AudioSource:
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 7fc556f529b0b4c2d882549c84b827ae, type: 3}
+  m_audioClip: {fileID: 8300000, guid: 312d47e0b008b47e787ac7b50cc8a075, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 0.5
   m_Pitch: 1
@@ -3004,7 +2355,7 @@ AudioSource:
       outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
-    m_RotationOrder: 0
+    m_RotationOrder: 4
   reverbZoneMixCustomCurve:
     serializedVersion: 2
     m_Curve:
@@ -3097,12 +2448,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 899064636}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &899284517 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 1712287588}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &900835210
 GameObject:
   m_ObjectHideFlags: 0
@@ -3133,13 +2478,10 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 989458721}
   - {fileID: 1209685342}
+  - {fileID: 514595437}
   - {fileID: 803571608}
-  - {fileID: 815884904}
-  - {fileID: 1882424234}
-  - {fileID: 2072355886}
-  - {fileID: 2146155049}
-  - {fileID: 1658217951}
   m_Father: {fileID: 563911783}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3161,7 +2503,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.166152, g: 0.166152, b: 0.184, a: 0.8627451}
+  m_Color: {r: 0.28676468, g: 0.28676468, b: 0.28676468, a: 0.578}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -3199,55 +2541,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   restartCountSize:
     serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: -0.0041656494
-      value: 0.0062561035
-      inSlope: 0.07561809
-      outSlope: 0.07561809
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.123871684
-      value: 0.4549448
-      inSlope: 10.84641
-      outSlope: 10.84641
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.2198619
-      value: 1.1043437
-      inSlope: 0.821377
-      outSlope: 0.821377
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.3932406
-      value: 1.0673077
-      inSlope: -1.0036296
-      outSlope: -1.0036296
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0.98747253
-      inSlope: -0.3473634
-      outSlope: -0.3473634
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
+    m_Curve: []
     m_PreInfinity: 2
     m_PostInfinity: 2
-    m_RotationOrder: 0
+    m_RotationOrder: 4
   SecondsBeforeReset: 10
 --- !u!1 &939587273
 GameObject:
@@ -3259,7 +2556,7 @@ GameObject:
   m_Component:
   - component: {fileID: 939587274}
   - component: {fileID: 939587275}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CornerCircle3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3328,63 +2625,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!4 &941020978 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 994003347}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &949926937
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 543230446}
-    m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point2Indicator
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!4 &949926938 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 949926937}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &989458720
 GameObject:
   m_ObjectHideFlags: 0
@@ -3396,6 +2636,7 @@ GameObject:
   - component: {fileID: 989458721}
   - component: {fileID: 989458723}
   - component: {fileID: 989458722}
+  - component: {fileID: 989458724}
   m_Layer: 0
   m_Name: EndText
   m_TagString: Untagged
@@ -3410,17 +2651,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 989458720}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1995125425}
+  m_Father: {fileID: 900835211}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -10}
-  m_SizeDelta: {x: 0, y: 400}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 269.3}
+  m_SizeDelta: {x: 500, y: 50}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &989458722
 MonoBehaviour:
@@ -3444,18 +2685,18 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 200
+    m_FontSize: 90
     m_FontStyle: 0
-    m_BestFit: 0
+    m_BestFit: 1
     m_MinSize: 0
-    m_MaxSize: 275
+    m_MaxSize: 90
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: 
+  m_Text: GAME OVER
 --- !u!222 &989458723
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3464,166 +2705,168 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 989458720}
   m_CullTransparentMesh: 0
---- !u!1001 &991221492
+--- !u!114 &989458724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 989458720}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.125, g: 0.125, b: 0.125, a: 0.5}
+  m_EffectDistance: {x: 2, y: -2}
+  m_UseGraphicAlpha: 1
+--- !u!1001 &1029701646
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11
+      value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.38268343
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.92387956
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 12
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4429568621961682, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 45
       objectReference: {fileID: 0}
-    - target: {fileID: 1302162468020258, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
+    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
       propertyPath: m_Name
-      value: Ball
+      value: SpawnPoint3
       objectReference: {fileID: 0}
-    - target: {fileID: 1319945779, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
-      propertyPath: viewIdField
-      value: 1
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.75
       objectReference: {fileID: 0}
-    - target: {fileID: 1319945779, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
-      propertyPath: InstantiationId
-      value: 1
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: SpawnPointNumber
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f2e7498d38698437d9749dd3a3998fba, type: 3}
---- !u!1001 &994003347
+  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
+--- !u!1001 &1037426595
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 543230446}
+    m_TransformParent: {fileID: 382124547}
     m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 27
+      value: -35
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point4Indicator
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!1001 &1015520393
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1188379735}
-    m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.y
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
+    - target: {fileID: 1162082726985520, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
       propertyPath: m_Name
-      value: Point3Indicator
+      value: CourtWallBottom (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.122
+      objectReference: {fileID: 0}
+    - target: {fileID: 61840166763336478, guid: 38c1f39e214884aa08f9583fab9ef3da,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 11.77
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!4 &1015520394 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 38c1f39e214884aa08f9583fab9ef3da, type: 3}
+--- !u!4 &1037426596 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
+  m_CorrespondingSourceObject: {fileID: 4422393910502112, guid: 38c1f39e214884aa08f9583fab9ef3da,
     type: 3}
-  m_PrefabInstance: {fileID: 1015520393}
+  m_PrefabInstance: {fileID: 1037426595}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1054179061
 GameObject:
@@ -3704,6 +2947,107 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1054179061}
   m_CullTransparentMesh: 0
+--- !u!1 &1060453119
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1060453120}
+  - component: {fileID: 1060453121}
+  m_Layer: 14
+  m_Name: PlayerBlocker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1060453120
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1060453119}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1299703921}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!60 &1060453121
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1060453119}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 10.67, y: 10.67}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 2.375, y: -0.965}
+      - {x: 2.455, y: -0.905}
+      - {x: 2.635, y: -0.72499996}
+      - {x: 2.705, y: -0.625}
+      - {x: 3.385, y: 0.235}
+      - {x: 3.475, y: 0.33499998}
+      - {x: 3.5549998, y: 0.435}
+      - {x: 3.875, y: 0.84499997}
+      - {x: 4.005, y: 0.98499995}
+      - {x: 4.015, y: 0.98499995}
+      - {x: 4.125, y: 1.0649999}
+      - {x: 4.1749997, y: 1.0849999}
+      - {x: 4.295, y: 1.145}
+      - {x: 4.455, y: 1.185}
+      - {x: 4.475, y: 1.2049999}
+      - {x: 4.4649997, y: 1.235}
+      - {x: -4.505, y: 1.235}
+      - {x: -4.525, y: 1.2149999}
+      - {x: -4.515, y: 1.185}
+      - {x: -4.4449997, y: 1.175}
+      - {x: -4.245, y: 1.125}
+      - {x: -4.095, y: 1.035}
+      - {x: -4.005, y: 0.97499996}
+      - {x: -3.995, y: 0.97499996}
+      - {x: -3.895, y: 0.865}
+      - {x: -3.8049998, y: 0.745}
+      - {x: -3.725, y: 0.645}
+      - {x: -3.675, y: 0.59499997}
+      - {x: -3.0249999, y: -0.205}
+      - {x: -2.8149998, y: -0.465}
+      - {x: -2.575, y: -0.765}
+      - {x: -2.5249999, y: -0.835}
+      - {x: -2.385, y: -0.97499996}
+      - {x: -2.325, y: -1.005}
+      - {x: -2.215, y: -1.055}
+      - {x: -2.115, y: -1.0849999}
+      - {x: -2.0049999, y: -1.105}
+      - {x: 0.355, y: -1.105}
+      - {x: 0.36499998, y: -1.115}
+      - {x: 1.405, y: -1.115}
+      - {x: 1.415, y: -1.125}
+      - {x: 1.9449999, y: -1.125}
+      - {x: 2.0149999, y: -1.115}
+      - {x: 2.105, y: -1.095}
+      - {x: 2.185, y: -1.0649999}
 --- !u!1 &1089955332
 GameObject:
   m_ObjectHideFlags: 0
@@ -3817,7 +3161,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 10}
+  m_AnchoredPosition: {x: 0, y: 150}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1103818599
@@ -3862,61 +3206,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1103818597}
   m_CullTransparentMesh: 0
---- !u!1 &1188379733
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1188379735}
-  - component: {fileID: 1188379734}
-  m_Layer: 0
-  m_Name: BlueScoreIndicator
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1188379734
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1188379733}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e5b0acf0fac824429a270aefa780a367, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  teamName: Blue
-  stops:
-  - {r: 0, g: 0, b: 0, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
-  - {r: 1, g: 1, b: 1, a: 1}
-  durations:
-  - 0.3
-  - 1
---- !u!4 &1188379735
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1188379733}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -70, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 256258894}
-  - {fileID: 1015520394}
-  - {fileID: 2135652616}
-  - {fileID: 164290749}
-  m_Father: {fileID: 0}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1209685341
 GameObject:
   m_ObjectHideFlags: 0
@@ -3928,6 +3217,7 @@ GameObject:
   - component: {fileID: 1209685342}
   - component: {fileID: 1209685344}
   - component: {fileID: 1209685343}
+  - component: {fileID: 1209685345}
   m_Layer: 0
   m_Name: WinnerText
   m_TagString: Untagged
@@ -3947,11 +3237,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 900835211}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 100}
+  m_AnchoredPosition: {x: 0, y: 18.9}
   m_SizeDelta: {x: 500, y: 90}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1209685343
@@ -3967,7 +3257,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.014705896, g: 0.9184584, b: 1, a: 1}
+  m_Color: {r: 0.88235295, g: 1, b: 0, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -3976,18 +3266,18 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 40
+    m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 1
-    m_MinSize: 4
+    m_MinSize: 10
     m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Blue team Won!
+  m_Text: Fire team won!
 --- !u!222 &1209685344
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3996,6 +3286,21 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1209685341}
   m_CullTransparentMesh: 0
+--- !u!114 &1209685345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1209685341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.1397059, g: 0.1397059, b: 0.1397059, a: 0.5}
+  m_EffectDistance: {x: 2, y: -2}
+  m_UseGraphicAlpha: 1
 --- !u!1001 &1229109133
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4005,15 +3310,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4166382533016198, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -2.2622766
       objectReference: {fileID: 0}
     - target: {fileID: 4166382533016198, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 12.32656
       objectReference: {fileID: 0}
     - target: {fileID: 4166382533016198, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.27263254
       objectReference: {fileID: 0}
     - target: {fileID: 4166382533016198, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
       propertyPath: m_LocalRotation.x
@@ -4033,7 +3338,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4166382533016198, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 114211205889215070, guid: e03ac4bb9f3ea4765985db4922a04b7a,
         type: 3}
@@ -4050,10 +3355,25 @@ PrefabInstance:
       propertyPath: backgroundScroller
       value: 
       objectReference: {fileID: 1521912373}
+    - target: {fileID: 114459257248822156, guid: e03ac4bb9f3ea4765985db4922a04b7a,
+        type: 3}
+      propertyPath: tutorialType
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1403289670529041876, guid: e03ac4bb9f3ea4765985db4922a04b7a,
         type: 3}
       propertyPath: viewIdField
       value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403289670529041876, guid: e03ac4bb9f3ea4765985db4922a04b7a,
+        type: 3}
+      propertyPath: InstantiationId
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7630974732043695949, guid: e03ac4bb9f3ea4765985db4922a04b7a,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
@@ -4084,22 +3404,15 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 276001309}
   - {fileID: 382124547}
-  - {fileID: 1826548446}
-  - {fileID: 1335570559}
-  - {fileID: 1673871025}
-  - {fileID: 1721664685}
   - {fileID: 1299703921}
+  - {fileID: 1826548446}
+  - {fileID: 1673871025}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1299703921 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1545037368569931285}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1335570558
+--- !u!1 &1232334279
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4107,157 +3420,245 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1335570559}
-  - component: {fileID: 1335570562}
-  - component: {fileID: 1335570561}
-  - component: {fileID: 1335570560}
-  m_Layer: 5
-  m_Name: InCourtCanvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1335570559
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1335570558}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 240401212}
-  m_Father: {fileID: 1229941009}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 128, y: 70}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1335570560
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1335570558}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 0
---- !u!114 &1335570561
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1335570558}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 100
---- !u!223 &1335570562
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1335570558}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 2
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 100
-  m_TargetDisplay: 0
---- !u!1 &1364312526
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1364312528}
-  - component: {fileID: 1364312527}
+  - component: {fileID: 1232334280}
   m_Layer: 0
-  m_Name: InControl
+  m_Name: TeamSelection
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1364312527
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1364312526}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c7b5e8de77c5b4597ae7fbfb49a95e22, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  logDebugInfo: 0
-  invertYAxis: 0
-  useFixedUpdate: 0
-  dontDestroyOnLoad: 0
-  suspendInBackground: 0
-  enableICade: 0
-  enableXInput: 0
-  xInputOverrideUpdateRate: 0
-  xInputUpdateRate: 0
-  xInputOverrideBufferSize: 0
-  xInputBufferSize: 0
-  enableNativeInput: 0
-  nativeInputEnableXInput: 1
-  nativeInputPreventSleep: 0
-  nativeInputOverrideUpdateRate: 0
-  nativeInputUpdateRate: 0
-  customProfiles: []
---- !u!4 &1364312528
+--- !u!4 &1232334280
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1364312526}
+  m_GameObject: {fileID: 1232334279}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1374163512}
+  - {fileID: 1833764181}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1299703920
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1299703921}
+  - component: {fileID: 1299703922}
+  - component: {fileID: 1299703923}
+  - component: {fileID: 1299703924}
+  - component: {fileID: 1299703925}
+  m_Layer: 13
+  m_Name: Goal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1299703921
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299703920}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -38.54, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_Children:
+  - {fileID: 809415599}
+  - {fileID: 1060453120}
+  m_Father: {fileID: 1229941009}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1299703922
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299703920}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 4
+  m_Sprite: {fileID: 21300000, guid: 6b264b702fb5d4fffa41c56209abc80d, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 10.67, y: 10.67}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!68 &1299703923
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299703920}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0.5
+  m_Points:
+  - {x: -5.836971, y: 1.1712635}
+  - {x: -4.5772533, y: 1.1708488}
+  - {x: -4.386651, y: 1.1346067}
+  - {x: -4.2032156, y: 1.0825285}
+  - {x: -4.0458894, y: 0.9648298}
+  - {x: -3.0369444, y: -0.27610144}
+  - {x: -2.916326, y: -0.41778946}
+  - {x: -2.8583465, y: -0.51595944}
+  - {x: -2.7446113, y: -0.62351227}
+  - {x: -2.6165957, y: -0.760802}
+  - {x: -2.5683002, y: -0.8251966}
+  - {x: -2.4467812, y: -0.9345843}
+  - {x: -2.305739, y: -1.0321325}
+  - {x: -2.1519284, y: -1.1061885}
+  - {x: -1.9446816, y: -1.146033}
+  - {x: 1.6796112, y: -1.1494281}
+  - {x: 1.901452, y: -1.1365688}
+  - {x: 2.0603497, y: -1.1199329}
+  - {x: 2.1889725, y: -1.0764148}
+  - {x: 2.3032079, y: -1.0228679}
+  - {x: 2.4433181, y: -0.9518344}
+  - {x: 2.578169, y: -0.8211238}
+  - {x: 2.659696, y: -0.7027525}
+  - {x: 3.9424338, y: 0.8800163}
+  - {x: 4.063236, y: 0.9861412}
+  - {x: 4.183382, y: 1.0677656}
+  - {x: 4.371149, y: 1.1404432}
+  - {x: 4.668666, y: 1.170124}
+  - {x: 6.1336336, y: 1.1560936}
+--- !u!114 &1299703924
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299703920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa589d0baa6d2499e9e8f8f5c0aaf36e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  respondToSwitchColliders: 0
+  playerBlocker: {fileID: 0}
+  ballBlocker: {fileID: 0}
+  fillRenderer: {fileID: 0}
+--- !u!60 &1299703925
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299703920}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.18}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 10.67, y: 10.67}
+    newSize: {x: 10.67, y: 10.67}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 2.375, y: -0.965}
+      - {x: 2.455, y: -0.905}
+      - {x: 2.635, y: -0.72499996}
+      - {x: 2.705, y: -0.625}
+      - {x: 3.385, y: 0.235}
+      - {x: 3.475, y: 0.33499998}
+      - {x: 3.5549998, y: 0.435}
+      - {x: 3.875, y: 0.84499997}
+      - {x: 4.005, y: 0.98499995}
+      - {x: 4.015, y: 0.98499995}
+      - {x: 4.125, y: 1.0649999}
+      - {x: 4.1749997, y: 1.0849999}
+      - {x: 4.295, y: 1.145}
+      - {x: 4.455, y: 1.185}
+      - {x: 4.475, y: 1.2049999}
+      - {x: 4.4649997, y: 1.235}
+      - {x: -4.505, y: 1.235}
+      - {x: -4.525, y: 1.2149999}
+      - {x: -4.515, y: 1.185}
+      - {x: -4.4449997, y: 1.175}
+      - {x: -4.245, y: 1.125}
+      - {x: -4.095, y: 1.035}
+      - {x: -4.005, y: 0.97499996}
+      - {x: -3.995, y: 0.97499996}
+      - {x: -3.895, y: 0.865}
+      - {x: -3.8049998, y: 0.745}
+      - {x: -3.725, y: 0.645}
+      - {x: -3.675, y: 0.59499997}
+      - {x: -3.0249999, y: -0.205}
+      - {x: -2.8149998, y: -0.465}
+      - {x: -2.575, y: -0.765}
+      - {x: -2.5249999, y: -0.835}
+      - {x: -2.385, y: -0.97499996}
+      - {x: -2.325, y: -1.005}
+      - {x: -2.215, y: -1.055}
+      - {x: -2.115, y: -1.0849999}
+      - {x: -2.0049999, y: -1.105}
+      - {x: 0.355, y: -1.105}
+      - {x: 0.36499998, y: -1.115}
+      - {x: 1.405, y: -1.115}
+      - {x: 1.415, y: -1.125}
+      - {x: 1.9449999, y: -1.125}
+      - {x: 2.0149999, y: -1.115}
+      - {x: 2.105, y: -1.095}
+      - {x: 2.185, y: -1.0649999}
 --- !u!1001 &1368724302
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4423,80 +3824,92 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1af76618cb7214497a6ecdbd292f11d1, type: 3}
---- !u!1 &1423437610
-GameObject:
+--- !u!1001 &1374163511
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1232334280}
+    m_Modifications:
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.7448565
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1792549931693360, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_Name
+      value: SelectPink
+      objectReference: {fileID: 0}
+    - target: {fileID: 114254539915204818, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: teamNumber
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 212183062335472288, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.9254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 212183062335472288, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.32941177
+      objectReference: {fileID: 0}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_FontData.m_Font
+      value: 
+      objectReference: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef,
+        type: 3}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_FontData.m_FontStyle
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224756690492993142, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1792549931693360, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_Layer
+      value: 15
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+--- !u!4 &1374163512 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1374163511}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1423437611}
-  - component: {fileID: 1423437613}
-  - component: {fileID: 1423437612}
-  m_Layer: 0
-  m_Name: BButtonImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1423437611
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1423437610}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.8, y: 0.8, z: 1}
-  m_Children: []
-  m_Father: {fileID: 786289546}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0.3, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.15, y: 0.5}
---- !u!114 &1423437612
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1423437610}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: b2631c3b7cce047c8bf87b5697e488ae, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &1423437613
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1423437610}
-  m_CullTransparentMesh: 0
 --- !u!1001 &1441604953
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4564,13 +3977,9 @@ PrefabInstance:
       propertyPath: m_SortingLayer
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
---- !u!1 &1487263835
+--- !u!1 &1446852930
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4578,125 +3987,78 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1487263836}
-  - component: {fileID: 1487263838}
-  - component: {fileID: 1487263837}
+  - component: {fileID: 1446852931}
+  - component: {fileID: 1446852933}
+  - component: {fileID: 1446852932}
   m_Layer: 0
-  m_Name: ControlsPanel
+  m_Name: SkipCount
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1487263836
+--- !u!224 &1446852931
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487263835}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1446852930}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1908593143}
-  - {fileID: 786289546}
-  m_Father: {fileID: 2082202136}
-  m_RootOrder: 1
+  m_LocalScale: {x: 0.9999984, y: 0.9999984, z: 0.9999984}
+  m_Children: []
+  m_Father: {fileID: 1796129066}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 720, y: 275}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1487263837
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 3.637979e-12, y: 10}
+  m_SizeDelta: {x: 0, y: 10}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1446852932
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487263835}
+  m_GameObject: {fileID: 1446852930}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_Color: {r: 0.8392157, g: 0.8392157, b: 0.8392157, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &1487263838
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
+    m_FontSize: 3
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 150
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1446852933
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487263835}
+  m_GameObject: {fileID: 1446852930}
   m_CullTransparentMesh: 0
---- !u!4 &1518960434 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4561929595844300, guid: 78dd080d2348342c09865e0967e82d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 1441604953}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1521912373 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 114296828198626906, guid: c51b9cfd5e3b344aaa02f6f29848e063,
-    type: 3}
-  m_PrefabInstance: {fileID: 1673871024}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2941ffa90bbc24625a176d92e41ac2f3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1528461986 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 1441604953}
-  m_PrefabAsset: {fileID: 0}
---- !u!61 &1528461987
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1528461986}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!1 &1654796400
+--- !u!1 &1493487804
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4704,42 +4066,42 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1654796401}
-  - component: {fileID: 1654796403}
-  - component: {fileID: 1654796402}
+  - component: {fileID: 1493487805}
+  - component: {fileID: 1493487807}
+  - component: {fileID: 1493487806}
   m_Layer: 0
-  m_Name: JustInTimeText
+  m_Name: ReadyUpCount
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1654796401
+--- !u!224 &1493487805
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1654796400}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1493487804}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.9999984, y: 0.9999984, z: 0.9999984}
   m_Children: []
-  m_Father: {fileID: 240401212}
-  m_RootOrder: 0
+  m_Father: {fileID: 1796129066}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -1.66}
+  m_AnchoredPosition: {x: 3.637979e-12, y: -8.22}
   m_SizeDelta: {x: -4, y: 10}
   m_Pivot: {x: 0.5, y: 1}
---- !u!114 &1654796402
+--- !u!114 &1493487806
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1654796400}
+  m_GameObject: {fileID: 1493487804}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
@@ -4767,89 +4129,32 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
---- !u!222 &1654796403
+--- !u!222 &1493487807
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1654796400}
+  m_GameObject: {fileID: 1493487804}
   m_CullTransparentMesh: 0
---- !u!1 &1658217950
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!4 &1518960434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4561929595844300, guid: 78dd080d2348342c09865e0967e82d70,
+    type: 3}
+  m_PrefabInstance: {fileID: 1441604953}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1658217951}
-  - component: {fileID: 1658217953}
-  - component: {fileID: 1658217952}
-  m_Layer: 0
-  m_Name: MetaControlsPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1658217951
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1658217950}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 611976304}
-  m_Father: {fileID: 900835211}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.18}
-  m_AnchorMax: {x: 0.5, y: 0.28}
-  m_AnchoredPosition: {x: -0.000061035156, y: -0.59399414}
-  m_SizeDelta: {x: 600, y: 0.19999695}
-  m_Pivot: {x: 0.5, y: 0.23}
---- !u!114 &1658217952
+--- !u!114 &1521912373 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 114296828198626906, guid: c51b9cfd5e3b344aaa02f6f29848e063,
+    type: 3}
+  m_PrefabInstance: {fileID: 1673871024}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1658217950}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 2941ffa90bbc24625a176d92e41ac2f3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &1658217953
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1658217950}
-  m_CullTransparentMesh: 0
 --- !u!1001 &1673871024
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4887,28 +4192,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4894121086552152, guid: c51b9cfd5e3b344aaa02f6f29848e063, type: 3}
       propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 114296828198626906, guid: c51b9cfd5e3b344aaa02f6f29848e063,
-        type: 3}
-      propertyPath: ppp
-      value: 
-      objectReference: {fileID: 11400000, guid: 1a5f9e5ce3c294ff7849bc0938f7228f,
-        type: 2}
-    - target: {fileID: 114296828198626906, guid: c51b9cfd5e3b344aaa02f6f29848e063,
-        type: 3}
-      propertyPath: chromeMagnitude
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 114296828198626906, guid: c51b9cfd5e3b344aaa02f6f29848e063,
-        type: 3}
-      propertyPath: transitionTime
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 114296828198626906, guid: c51b9cfd5e3b344aaa02f6f29848e063,
-        type: 3}
-      propertyPath: chrome
-      value: 
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c51b9cfd5e3b344aaa02f6f29848e063, type: 3}
@@ -5089,57 +4373,6 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 0
   countdownText: {fileID: 1103818599}
---- !u!1001 &1712287588
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 543230446}
-    m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -27
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point1Indicator
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!4 &1721664685 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4262072401159130, guid: e52e78f4f7ff34ea4b521c3212c59269,
-    type: 3}
-  m_PrefabInstance: {fileID: 479130578}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1746785893
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5177,11 +4410,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4176559547740574, guid: d0a7057ebfe26409199e46593e19d260, type: 3}
       propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1724099838662006, guid: d0a7057ebfe26409199e46593e19d260, type: 3}
-      propertyPath: m_Layer
-      value: 16
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d0a7057ebfe26409199e46593e19d260, type: 3}
@@ -5276,38 +4505,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1774596749}
   m_CullTransparentMesh: 0
---- !u!1 &1785047798 stripped
+--- !u!1 &1796129065
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70,
-    type: 3}
-  m_PrefabInstance: {fileID: 857941354}
-  m_PrefabAsset: {fileID: 0}
---- !u!61 &1785047799
-BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1785047798}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1796129066}
+  - component: {fileID: 1796129069}
+  - component: {fileID: 1796129068}
+  m_Layer: 0
+  m_Name: Ready
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1796129066
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796129065}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.99444157, y: 0.99444157, z: 0.99444157}
+  m_Children:
+  - {fileID: 2072423246}
+  - {fileID: 589976235}
+  - {fileID: 1493487805}
+  - {fileID: 312273608}
+  - {fileID: 1446852931}
+  m_Father: {fileID: 276001309}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000061035156, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1796129068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796129065}
   m_Enabled: 1
-  m_Density: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &1796129069
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796129065}
+  m_CullTransparentMesh: 0
 --- !u!1 &1826548445
 GameObject:
   m_ObjectHideFlags: 0
@@ -5345,74 +4621,104 @@ Transform:
   - {fileID: 244845674}
   - {fileID: 439086876}
   m_Father: {fileID: 1229941009}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1882424233
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1882424234}
-  - component: {fileID: 1882424237}
-  - component: {fileID: 1882424235}
-  m_Layer: 0
-  m_Name: MainMenuInstructionX
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1882424234
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882424233}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000024, y: 1.0000024, z: 1.0000024}
-  m_Children: []
-  m_Father: {fileID: 900835211}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 264.7}
-  m_SizeDelta: {x: 500, y: 42.6}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!114 &1882424235
-MonoBehaviour:
+--- !u!1001 &1833764180
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1232334280}
+    m_Modifications:
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.7448565
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1792549931693360, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_Name
+      value: SelectBlue
+      objectReference: {fileID: 0}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 212183062335472288, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 212183062335472288, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.91724133
+      objectReference: {fileID: 0}
+    - target: {fileID: 212183062335472288, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_FontData.m_Font
+      value: 
+      objectReference: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef,
+        type: 3}
+    - target: {fileID: 114734808852496384, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+        type: 3}
+      propertyPath: m_FontData.m_FontStyle
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1792549931693360, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+      propertyPath: m_Layer
+      value: 15
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3, type: 3}
+--- !u!4 &1833764181 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4437968716897286, guid: d8cc9d9c4d4ae4721a000c9d2c739eb3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1833764180}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882424233}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 83f6c6be0b17d4b5693782a205a1eda1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fontSize: 40
-  initialSpacing: 0
-  elementSpacing: 5
-  imageVerticalSpacing: 0
-  center: 1
-  textColor: {r: 1, g: 1, b: 1, a: 1}
-  textPrefabName: RichTextPrefabs/RichElementText
-  imagePrefabName: RichTextPrefabs/RichElementImage
-  initialContent: <XButton>  START NEW GAME
---- !u!222 &1882424237
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882424233}
-  m_CullTransparentMesh: 0
 --- !u!1001 &1891255964
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5484,10 +4790,6 @@ PrefabInstance:
       propertyPath: m_SortingLayer
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 1583598543925102, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
-      propertyPath: m_Layer
-      value: 17
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 78dd080d2348342c09865e0967e82d70, type: 3}
 --- !u!4 &1891255965 stripped
@@ -5496,166 +4798,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1891255964}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1908593142
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1908593143}
-  - component: {fileID: 1908593145}
-  - component: {fileID: 1908593144}
-  m_Layer: 0
-  m_Name: AButtonPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1908593143
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1908593142}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 782831856}
-  - {fileID: 682600854}
-  m_Father: {fileID: 1487263836}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.75}
---- !u!114 &1908593144
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1908593142}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &1908593145
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1908593142}
-  m_CullTransparentMesh: 0
---- !u!1001 &1947249383
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 27.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.38268343
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.92387956
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -45
-      objectReference: {fileID: 0}
-    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_Name
-      value: SpawnPoint2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
-        type: 3}
-      propertyPath: SpawnPointNumber
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
 --- !u!1001 &1960686068
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5721,8 +4863,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1983203107}
   - component: {fileID: 1983203108}
-  - component: {fileID: 1983203109}
-  m_Layer: 17
+  m_Layer: 0
   m_Name: CornerCircle4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5791,165 +4932,90 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &1983203109
-CircleCollider2D:
+--- !u!1001 &2059969246
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1983203106}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
---- !u!1 &1995125424
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1995125425}
-  - component: {fileID: 1995125427}
-  - component: {fileID: 1995125426}
-  - component: {fileID: 1995125428}
-  m_Layer: 0
-  m_Name: EndTextPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1995125425
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995125424}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 989458721}
-  m_Father: {fileID: 563911783}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1995125426
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995125424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
---- !u!222 &1995125427
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995125424}
-  m_CullTransparentMesh: 0
---- !u!114 &1995125428
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995125424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad487e4f7f5534db18982ecd07f5ddda, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  textSize:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: -0.0041656494
-      value: 0.0062561035
-      inSlope: 0.07561809
-      outSlope: 0.07561809
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.123871684
-      value: 0.4549448
-      inSlope: 10.84641
-      outSlope: 10.84641
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.2198619
-      value: 1.1043437
-      inSlope: 0.821377
-      outSlope: 0.821377
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.3932406
-      value: 1.0673077
-      inSlope: -1.0036296
-      outSlope: -1.0036296
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0.98747253
-      inSlope: -0.3473634
-      outSlope: -0.3473634
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  minTextSize: 75
-  maxTextSize: 200
-  textLerpDuration: 1
-  endTextContent: Game!
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.38268343
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.92387956
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: SpawnPointNumber
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}
 --- !u!1 &2067126164
 GameObject:
   m_ObjectHideFlags: 0
@@ -6016,7 +5082,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2072355885
+--- !u!1 &2072423245
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6024,64 +5090,64 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2072355886}
-  - component: {fileID: 2072355888}
-  - component: {fileID: 2072355889}
+  - component: {fileID: 2072423246}
+  - component: {fileID: 2072423248}
+  - component: {fileID: 2072423249}
   m_Layer: 0
-  m_Name: MainMenuInstructionY
+  m_Name: ReadyUpText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &2072355886
+--- !u!224 &2072423246
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2072355885}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 2072423245}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000056, y: 1.0000056, z: 1.0000056}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 900835211}
-  m_RootOrder: 4
+  m_Father: {fileID: 1796129066}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 210.14}
-  m_SizeDelta: {x: 500, y: 42.6}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -3.08}
+  m_SizeDelta: {x: 124, y: 5.19}
   m_Pivot: {x: 0.5, y: 1}
---- !u!222 &2072355888
+--- !u!222 &2072423248
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2072355885}
+  m_GameObject: {fileID: 2072423245}
   m_CullTransparentMesh: 0
---- !u!114 &2072355889
+--- !u!114 &2072423249
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2072355885}
+  m_GameObject: {fileID: 2072423245}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 83f6c6be0b17d4b5693782a205a1eda1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fontSize: 40
+  fontSize: 20
   initialSpacing: 0
-  elementSpacing: 5
-  imageVerticalSpacing: 0
+  elementSpacing: 0
+  imageVerticalSpacing: 0.03
   center: 1
-  textColor: {r: 1, g: 1, b: 1, a: 1}
+  textColor: {r: 0.8392157, g: 0.8392157, b: 0.8392157, a: 1}
   textPrefabName: RichTextPrefabs/RichElementText
   imagePrefabName: RichTextPrefabs/RichElementImage
-  initialContent: <YButton>  PICK NEW TEAMS
+  initialContent: HOLD AND RELEASE <AButton> TO DASH
 --- !u!1 &2082202133
 GameObject:
   m_ObjectHideFlags: 0
@@ -6113,7 +5179,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.166152, g: 0.166152, b: 0.184, a: 0.8627451}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -6149,212 +5215,96 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 198209133}
-  - {fileID: 1487263836}
-  - {fileID: 176022097}
+  - {fileID: 687356461}
   m_Father: {fileID: 563911783}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 2, y: 2}
+  m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &2135652615
+--- !u!1001 &678259103366255743
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1188379735}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1047917975685604, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
-      propertyPath: m_Name
-      value: Point2Indicator
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4ece140ee1e6d418eacea6a6d609f489, type: 3}
---- !u!4 &2135652616 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4809706271367506, guid: 4ece140ee1e6d418eacea6a6d609f489,
-    type: 3}
-  m_PrefabInstance: {fileID: 2135652615}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2146155048
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2146155049}
-  - component: {fileID: 2146155051}
-  - component: {fileID: 2146155050}
-  m_Layer: 0
-  m_Name: MainMenuInstructionDPad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &2146155049
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146155048}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000056, y: 1.0000056, z: 1.0000056}
-  m_Children: []
-  m_Father: {fileID: 900835211}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 219.94002}
-  m_SizeDelta: {x: 500, y: 90}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!114 &2146155050
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146155048}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 958c101a50ca644c587b7ef2d3c2afef, type: 3}
-    m_FontSize: 40
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 4
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: "\n \n\nD-pad up:       Main menu"
---- !u!222 &2146155051
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146155048}
-  m_CullTransparentMesh: 0
---- !u!1001 &1545037368569931285
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1229941009}
-    m_Modifications:
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 15
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -38.54
+      value: 15
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.92387956
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.38268343
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930660, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: -135
       objectReference: {fileID: 0}
-    - target: {fileID: 1545037367308930661, guid: 03201c32840fa452c9dca448868f2be7,
+    - target: {fileID: 813334746742545517, guid: 86e8f55c20d654b5a96f40379e0d9f21,
         type: 3}
       propertyPath: m_Name
-      value: Goal
+      value: SpawnPoint1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4080437710676593902, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 885492724510561715, guid: 86e8f55c20d654b5a96f40379e0d9f21,
+        type: 3}
+      propertyPath: SpawnPointNumber
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 03201c32840fa452c9dca448868f2be7, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 86e8f55c20d654b5a96f40379e0d9f21, type: 3}

--- a/Assets/Scenes/court-networked-lobby.unity.meta
+++ b/Assets/Scenes/court-networked-lobby.unity.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fbd5d415216484587946ebb7d6385fe1
+timeCreated: 1519352962
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/court-team-selection.unity
+++ b/Assets/Scenes/court-team-selection.unity
@@ -3303,6 +3303,21 @@ PrefabInstance:
       propertyPath: tutorialType
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1403289670529041876, guid: e03ac4bb9f3ea4765985db4922a04b7a,
+        type: 3}
+      propertyPath: viewIdField
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403289670529041876, guid: e03ac4bb9f3ea4765985db4922a04b7a,
+        type: 3}
+      propertyPath: InstantiationId
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 114459257248822156, guid: e03ac4bb9f3ea4765985db4922a04b7a,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e03ac4bb9f3ea4765985db4922a04b7a, type: 3}
 --- !u!1 &1229941008
@@ -3513,13 +3528,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fa589d0baa6d2499e9e8f8f5c0aaf36e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  goalSwitchInterval: 10
-  goalSwitchNotificationLength: 3
-  goalSwitchWarningVolume: 0.02
-  timedSwitching: 0
-  playerPassSwitching: 1
   respondToSwitchColliders: 0
-  resetTimerOnSwitchToSameTeam: 0
+  playerBlocker: {fileID: 0}
+  ballBlocker: {fileID: 0}
+  fillRenderer: {fileID: 0}
 --- !u!60 &1299703925
 PolygonCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ball/BallColorManager.cs
+++ b/Assets/Scripts/Ball/BallColorManager.cs
@@ -9,8 +9,6 @@ public class BallColorManager : MonoBehaviour
     private SpriteRenderer outerRingRenderer;
     [SerializeField]
     private SpriteRenderer innerFillRenderer;
-    [SerializeField]
-    private Color neutralColor = Color.white;
 
     private TrailRenderer trailRenderer;
     private Coroutine delayedTrailEnable;
@@ -45,7 +43,7 @@ public class BallColorManager : MonoBehaviour
     private void ResetToNeutral()
     {
         trailRenderer.enabled = false;
-        outerRingRenderer.color = neutralColor;
+        outerRingRenderer.color = GameManager.Settings.NeutralColor;
         innerFillRenderer.enabled = false;
     }
 

--- a/Assets/Scripts/Court/PlayerSpawnPoint.cs
+++ b/Assets/Scripts/Court/PlayerSpawnPoint.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// This component does nothing except effectively register a transform (position
+// and rotation) with the spawn point manager
+public class PlayerSpawnPoint : MonoBehaviour
+{
+    public int SpawnPointNumber = 0;
+    void Start()
+    {
+        SpawnPointManager.Instance.SpawnPoints.Add(SpawnPointNumber, this);
+    }
+}

--- a/Assets/Scripts/Court/PlayerSpawnPoint.cs.meta
+++ b/Assets/Scripts/Court/PlayerSpawnPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68853aae7b4eb4400a9e3aac0639e66b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Court/TeamSelectionCollider.cs
+++ b/Assets/Scripts/Court/TeamSelectionCollider.cs
@@ -25,7 +25,7 @@ public class TeamSelectionCollider : MonoBehaviour
         }, 2);
     }
 
-    private void OnCollisionStay2D(Collision2D collision)
+    private void OnCollisionEnter2D(Collision2D collision)
     {
         Player player = collision.gameObject.GetComponent<Player>();
         if (player != null && team != null && player.Team != team)
@@ -33,7 +33,13 @@ public class TeamSelectionCollider : MonoBehaviour
             PlayerStateManager stateManager = player.GetComponent<PlayerStateManager>();
             if (stateManager != null)
             {
-                if (mustDashToSwitch && stateManager.CurrentState != State.Dash)
+                // The player could have already transitioned to a different state
+                // after running into the team selection collider, so we also need to check
+                // if the previous state was dash and if the player changed states in this frame.
+                bool playerHitWhileDashing = stateManager.CurrentState == State.Dash ||
+                    (stateManager.PreviousState == State.Dash &&
+                    (Time.time - stateManager.TimeOfLastStateChange) < Time.deltaTime);
+                if (mustDashToSwitch && !playerHitWhileDashing)
                 {
                     // Only switch if dashing
                     return;

--- a/Assets/Scripts/Court/TeamSelectionCollider.cs
+++ b/Assets/Scripts/Court/TeamSelectionCollider.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.UI;
 using UtilityExtensions;
 
@@ -39,7 +39,10 @@ public class TeamSelectionCollider : MonoBehaviour
                     return;
                 }
             }
-            if (player.Team != team && team.teamMembers.Count < maxOnTeam)
+            // Networking info: local team selection doesn't apply to non-local
+            // players. Instead we wait for them to send us their team state.
+            if (player.Team != team && team.teamMembers.Count < maxOnTeam &&
+                player.photonView.IsMine)
             {
                 player.SetTeam(team);
                 AudioManager.instance.Ching.Play();
@@ -68,6 +71,7 @@ public class TeamSelectionCollider : MonoBehaviour
 
     private void FixedUpdate()
     {
+        // TODO refactor to use the TeamsChanged event
         if (team != null && team.teamMembers.Count != lastCount)
         {
             if (countText != null)

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -28,7 +28,6 @@ public class GameManager : MonoBehaviour
     public NamedColor[] teamColors;
     public List<TeamManager> Teams { get; set; }
     public TeamResourceManager neutralResources;
-    
     public bool gameOver { get; private set; } = false;
     public TeamManager Winner { get; private set; } = null;
     public GameObject meta;
@@ -138,6 +137,24 @@ public class GameManager : MonoBehaviour
         return null;
     }
 
+    // Used for pre-player object initialization, i.e. figuring out where to
+    // spawn in new player objects during the "court pre-period". This period is
+    // where no player objects exist, but all information about which objects
+    // should exist, which teams they're on, and where they should spawn, is all
+    // available through various static/room property maps of ints to ints.
+    public TeamManager GetTeamAssignment(int playerNumber)
+    {
+        if (GameManager.playerTeamsAlreadySelected)
+        {
+            return Teams[playerTeamAssignments[playerNumber]];
+        }
+        else if (GameManager.cheatForcePlayerAssignment)
+        {
+            return Teams[playerNumber % Teams.Count];
+        }
+        return null;
+    }
+
     private void InitializeTeams()
     {
         Teams = new List<TeamManager>();
@@ -180,6 +197,17 @@ public class GameManager : MonoBehaviour
             result.AddRange(team.teamMembers);
         }
         return result;
+    }
+
+    // Networking info: frequently we need to work with/store player numbers
+    // rather than player objects, due to network-synced data structures. This
+    // utility function allows easy access to players given their player number,
+    // but should potentially (and very easily could) be replaced with something
+    // more efficient if it ends up being used in a tight loop.
+    public Player GetPlayerFromNumber(int playerNumber) {
+        return (from player in players
+                where player.playerNumber == playerNumber
+                select player).FirstOrDefault();
     }
 
     public List<Player> GetAllPlayers()

--- a/Assets/Scripts/Managers/GameSettings.cs
+++ b/Assets/Scripts/Managers/GameSettings.cs
@@ -17,4 +17,5 @@ public class GameSettings
     public float PauseAfterGoalScore = 3f;
     [Tooltip("The length of the ball implosion animation")]
     public float LengthOfBallSpawnAnimation = 2f;
+    public Color NeutralColor = Color.white;
 }

--- a/Assets/Scripts/Managers/LobbyManager.cs
+++ b/Assets/Scripts/Managers/LobbyManager.cs
@@ -32,6 +32,10 @@ public class LobbyManager : MonoBehaviourPunCallbacks {
     }
     void Start() {
         GameManager.NotificationManager.CallOnMessage(Message.TeamsChanged, HandleTeamsChanged);
+        // Force skip lobby
+        // TODO gate this behind debug flag
+        GameManager.NotificationManager.CallOnMessage(Message.PlayerPressedRightBumper,
+                                                      EndTeamSelection);
     }
 
     void HandleTeamsChanged() {

--- a/Assets/Scripts/Managers/LobbyManager.cs
+++ b/Assets/Scripts/Managers/LobbyManager.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
+using System.Linq;
+using System.Collections.Generic;
+using UtilityExtensions;
+
+// The LobbyManager effectively replaces previous "tutorial" classes
+// (specifically PlayerTutorial, not TutorialLiveClips), in their scene
+// transition responsibilities.
+public class LobbyManager : MonoBehaviourPunCallbacks {
+    void Awake() {
+        if (!GameManager.playerTeamsAlreadySelected) {
+            // This variable should only prevent the start countdown from
+            // running, at the moment
+            PlayerTutorial.runTutorial = true;
+            // This variable should already default to false and never be set to
+            // true in the current flow, but keeping it just in case.
+            // TODO clean up this variable
+            GameManager.cheatForcePlayerAssignment = false;
+            // This variable is actually relevant. It defaults to false, but
+            // setting it again here ensures reloads of the lobby stay correct.
+            // There should actually be no difference between this variable and
+            // GameManager.playerTeamsAlreadySelected, logically, but they're
+            // already used in different places.
+            // TOOD Clean up this variable/merge with playerTeamsAlreadySelected
+            TeamManager.playerSpritesAlreadySet = false;
+            // Should be obvious, enables the JITT in the court. Although that's
+            // non-functional at the moment I think.
+            JustInTimeTutorial.alreadySeen = false;
+        }
+    }
+    void Start() {
+        GameManager.NotificationManager.CallOnMessage(Message.TeamsChanged, HandleTeamsChanged);
+    }
+
+    void HandleTeamsChanged() {
+        if (GameManager.Instance.Teams.All(team => team.teamMembers.Count == 2)) {
+            EndTeamSelection();
+        }
+    }
+
+    void EndTeamSelection() {
+        if (!GameManager.playerTeamsAlreadySelected) {
+            // Set the static variable which tells the game as a whole to use
+            // various static data structures to determine player teams.
+            GameManager.playerTeamsAlreadySelected = true;
+            // Fill in that static structure (to persist over scene loads) with
+            // the current TeamManager object information
+            GameManager.playerTeamAssignments = new Dictionary<int, int>();
+            foreach (Player player in GameManager.Instance.GetPlayersWithTeams())
+            {
+                int teamIndex = GameManager.Instance.Teams.IndexOf(player.Team);
+                GameManager.playerTeamAssignments[player.playerNumber] = teamIndex;
+            }
+            // Basically the same semantics as playerTeamsAlreadySelected but
+            // used in TeamManager instead of elsewhere
+            TeamManager.playerSpritesAlreadySet = true;
+            // Call the scene load methods. This won't actually load the scene
+            // on any non-master client (the auto scene syncing takes care of
+            // final loading).
+            SceneStateManager.instance.Load(Scene.Court);
+        }
+    }
+}

--- a/Assets/Scripts/Managers/LobbyManager.cs.meta
+++ b/Assets/Scripts/Managers/LobbyManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5db7da1130502406ab691886a66549bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/NetworkTeamManager.cs
+++ b/Assets/Scripts/Managers/NetworkTeamManager.cs
@@ -142,7 +142,6 @@ public class NetworkTeamManager : MonoBehaviourPunCallbacks, IConnectionCallback
     public void PushToTeamManagers() {
         var stateCopy = new Dictionary<int, Dictionary<int, int>>(teamState);
         foreach (var (teamNumber, teamData) in stateCopy) {
-            Debug.LogError(teamNumber);
             var team = (from t in GameManager.Instance.Teams
                             where t.TeamNumber == teamNumber
                             select t).First();

--- a/Assets/Scripts/Managers/NetworkTeamManager.cs
+++ b/Assets/Scripts/Managers/NetworkTeamManager.cs
@@ -1,0 +1,155 @@
+using System.Collections;
+using System.Linq;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
+using UtilityExtensions;
+using Hashtable = ExitGames.Client.Photon.Hashtable;
+
+// This class handles syncing state between TeamManagers across the network.
+// It's only necessary in the lobby, where team state can actually change.
+//
+// TODO this follows a very similar usage patter of room properties as the
+// NetworkPlayerManager, should generalize the pattern and refactor
+public class NetworkTeamManager : MonoBehaviourPunCallbacks, IConnectionCallbacks, IInRoomCallbacks
+{
+    public static string TEAMS_PROPERTY_KEY = "__TeamsPropertyKey__";
+    public static NetworkTeamManager Instance { get; set; }
+
+    // In the Court scene, there's no reason for this class to do anything (and
+    // some errors occur if it's still running).
+    //
+    // TODO disable this and actually fix those errors. Minor cleanup.
+    bool doNothing = false;
+    // Map team number to a map of player numbers to sprite numbers.
+    Dictionary<int, Dictionary<int, int>> teamState = new Dictionary<int, Dictionary<int, int>>();
+
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(this);
+        }
+    }
+
+    void Start() {
+        if (GameManager.playerTeamsAlreadySelected) {
+            // If the network team manager is initialized in a scene where teams
+            // have already been selected, there's no reason to continue syncing
+            // team information. It's static for the rest of the game.
+            doNothing = true;
+        }
+        // TODO if we wanted state to remain synced in Court, after scene load,
+        // we would have to do a LoadRoomProperties in start rather than room
+        // join (since the room is already joined in court now). We don't
+        // actually want this, just here as an example of usage of this room
+        // properties pattern
+        //
+        // if (PhotonNetwork.InRoom) {
+        //     LoadRoomProperties();
+        //     this.FrameDelayCall(() => Pull(), 2);
+        // }
+    }
+
+    /// <summary> Ensures team data is populated by the first player to ender
+    /// the room
+    /// </summary>
+    void EnsureRoomPropertiesExist()
+    {
+        if (!PhotonNetwork.CurrentRoom.CustomProperties.ContainsKey(TEAMS_PROPERTY_KEY))
+        {
+            var outData = new Hashtable();
+            outData.Add(TEAMS_PROPERTY_KEY, new Dictionary<int, Dictionary<int, int>>());
+            PhotonNetwork.CurrentRoom.SetCustomProperties(outData);
+        }
+    }
+
+    /// <summary>
+    /// Load the networked property data to the local variables.
+    /// </summary>
+    void LoadRoomProperties()
+    {
+        teamState = PhotonNetwork.CurrentRoom.CustomProperties[TEAMS_PROPERTY_KEY] as Dictionary<int, Dictionary<int, int>>;
+    }
+
+    /// <summary>
+    /// Push the values of the local variables to the networked properties
+    /// </summary>
+    void SetRoomPropertiesFromLocalData()
+    {
+        Hashtable outData = new Hashtable {
+            {TEAMS_PROPERTY_KEY, teamState}
+        };
+        PhotonNetwork.CurrentRoom.SetCustomProperties(outData);
+    }
+
+    // Push data from the local state to the network
+    public void Push() {
+        if (doNothing) {return;}
+        ReadFromTeamManagers();
+        SetRoomPropertiesFromLocalData();
+    }
+
+    // Pull data from the network to the local state
+    public void Pull() {
+        if (doNothing) {return;}
+        LoadRoomProperties();
+        PushToTeamManagers();
+    }
+
+    // TODO think this is totally unused
+    public int SpriteNumber(int teamNumber, int playerNumber) {
+        Utility.Print("In sprite number FIRST", teamNumber, playerNumber, LogLevel.Error);
+        foreach (var (t, d) in teamState) {
+            foreach (var (p, s) in d) {
+                Utility.Print("In sprite number", t, p, s, LogLevel.Error);
+            }
+        }
+        return teamState[teamNumber - 1][playerNumber];
+    }
+
+    public override void OnJoinedRoom()
+    {
+        if (PhotonNetwork.CurrentRoom.PlayerCount == 1)
+        {
+            EnsureRoomPropertiesExist();
+        }
+        // TODO frame delay call: can't remember/maybe never knew why this is
+        // necessary, only that things broke without it. Should investigate and
+        // remove.
+        this.FrameDelayCall(() =>{ Pull(); });
+    }
+
+    public override void OnRoomPropertiesUpdate(Hashtable propertiesThatChanged) {
+        Debug.LogError("Room properties updated");
+        // TODO frame delay call: can't remember/maybe never knew why this is
+        // necessary, only that things broke without it. Should investigate and
+        // remove.
+        this.FrameDelayCall(() =>{ Pull(); });
+    }
+
+    public void ReadFromTeamManagers() {
+        foreach (var team in GameManager.Instance.Teams) {
+            teamState[team.TeamNumber] = team.ConvertForNetwork();
+        }
+    }
+
+    public void PushToTeamManagers() {
+        var stateCopy = new Dictionary<int, Dictionary<int, int>>(teamState);
+        foreach (var (teamNumber, teamData) in stateCopy) {
+            Debug.LogError(teamNumber);
+            var team = (from t in GameManager.Instance.Teams
+                            where t.TeamNumber == teamNumber
+                            select t).First();
+            foreach (var (playerNumber, spriteNumber) in teamData) {
+                var player = GameManager.Instance.GetPlayerFromNumber(playerNumber);
+                player.SetTeam(team, spriteNumber);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Managers/NetworkTeamManager.cs.meta
+++ b/Assets/Scripts/Managers/NetworkTeamManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d509d0fe8a05844eda7bd3b705cbc477
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/NotificationManager.cs
+++ b/Assets/Scripts/Managers/NotificationManager.cs
@@ -24,6 +24,7 @@ public enum Message
     StartCountdown,
     CountdownFinished,
     PlayerAssignedPlayerNumber,
+    TeamsChanged,
 
     // Game events
     GoalScored,
@@ -142,7 +143,7 @@ public class NotificationManager
         {
             onAnyPlayerExitStateSubscribers[state] += callback;
         }
-        
+
     }
 
     public void CallOnMessageWithSender(Message event_type, EventCallback callback, bool early = false)

--- a/Assets/Scripts/Managers/PlayerStateManager.cs
+++ b/Assets/Scripts/Managers/PlayerStateManager.cs
@@ -33,7 +33,34 @@ public enum State : byte
 
 public class PlayerStateManager : MonoBehaviourPun, IPunObservable
 {
-    public State CurrentState { private set; get; } = State.StartupState;
+    private State _currentState = State.StartupState;
+    public State CurrentState {
+        private set
+        {
+            TimeOfLastStateChange = Time.time;
+            PreviousState = _currentState;
+            _currentState = value;
+        }
+        get
+        {
+            return _currentState;
+        }
+    }
+
+    /// <summary>
+    /// The Time.time of when the player last changed states
+    /// </summary>
+    public float TimeOfLastStateChange { get; private set; }
+
+    /// <summary>
+    /// The state the player was in before the current state
+    /// </summary>
+    public State PreviousState { get; private set; }
+
+    /// <summary>
+    /// The information of the previous state, if there is any, null otherwise.
+    /// </summary>
+    public StateTransitionInformation PreviousStateInformation => stateInfos[PreviousState];
 
     // TODO dkonik: I can potentially see an ordering issue with this being one
     // event. This may need to be split up into two events (OnStateEnded and

--- a/Assets/Scripts/Managers/PlayerStateManager.cs
+++ b/Assets/Scripts/Managers/PlayerStateManager.cs
@@ -135,7 +135,7 @@ public class PlayerStateManager : MonoBehaviourPun, IPunObservable
     public void TransitionToState(State state, StateTransitionInformation transitionInfo = null)
     {
         if (!photonView.IsMine) {
-            Utility.Print("Tried to transition to state on non-owned player", LogLevel.Error);
+            Utility.Print("Tried to transition to state on non-owned player from", CurrentState, "to", state, LogLevel.Error);
         }
         // Some error checking. If this is a state which contains an information object
         if (stateInfos[state] != null)

--- a/Assets/Scripts/Managers/SceneStateManager.cs
+++ b/Assets/Scripts/Managers/SceneStateManager.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Photon.Realtime;
+using Photon.Pun;
 
 public enum Scene
 {
@@ -77,7 +79,15 @@ public class SceneStateManager : MonoBehaviour
             TeamManager.playerSpritesAlreadySet = false;
             JustInTimeTutorial.alreadySeen = false;
         }
-        SceneManager.LoadScene(scenes[currentScene]);
+        // No longer directly load scenes, instead use Photon to do it. In
+        // Photon the pattern is to allow the master to actually call LoadLevel,
+        // and with auto scene sync on all clients will follow suit.
+        //
+        // Must use this instead of normal level loading to allow PhotonViews to
+        // be correctly cleaned up.
+        if (PhotonNetwork.IsMasterClient) {
+            PhotonNetwork.LoadLevel(scenes[currentScene]);
+        }
         AdjustTime(newScene);
         OnEnter[currentScene]();
 

--- a/Assets/Scripts/Managers/SpawnPointManager.cs
+++ b/Assets/Scripts/Managers/SpawnPointManager.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
+
+// Handles spawning of networked players at correct spawn points
+public class SpawnPointManager : MonoBehaviour
+{
+    public static SpawnPointManager Instance = null;
+    public SortedList<int, PlayerSpawnPoint> SpawnPoints = new SortedList<int, PlayerSpawnPoint>();
+
+    void Awake() {
+        if (Instance == null) {
+            Instance = this;
+        } else {
+            Destroy(this);
+        }
+    }
+
+    private PlayerSpawnPoint SpawnPointForPlayer(int playerNumber) {
+        if (GameManager.playerTeamsAlreadySelected) {
+            var team = GameManager.Instance.GetTeamAssignment(playerNumber);
+            var spawnPointIndex = team.PlayerToSpawnPoint(playerNumber);
+            return SpawnPoints[spawnPointIndex];
+        } else {
+            return SpawnPoints[playerNumber];
+        }
+    }
+
+    public Player SpawnPlayerWithNumber(int playerNumber) {
+        var spawnPoint = SpawnPointForPlayer(playerNumber);
+        // Players that are instantiated from scratch start with a player number
+        // of 0. While locally, we can set the player number in this function,
+        // this isn't called in other clients. Instead we rely on the
+        // instantiationData feature of Photon views. We send the player number
+        // in the object array of data, and the Player Start() handles checking
+        // for the existence of this data and setting its player number.
+        //
+        // This does mean currently only this class correctly encapsulates
+        // spawning a new player, so it's really more of a PlayerSpawningManager
+        // than just a SpawnPointManager...
+        //
+        // TODO Update class name
+        var data = new object[] {playerNumber};
+        var playerObject = PhotonNetwork.Instantiate("Player", spawnPoint.transform.position,
+                                                     spawnPoint.transform.rotation, 0, data);
+        var player = playerObject.GetComponent<Player>();
+        player.playerNumber = playerNumber;
+        player.initialPosition = player.transform.position;
+        player.initialRotation = player.GetComponent<Rigidbody2D>().rotation;
+        return player;
+    }
+}

--- a/Assets/Scripts/Managers/SpawnPointManager.cs.meta
+++ b/Assets/Scripts/Managers/SpawnPointManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f4379ef8320643b8ad7b8d32f139f83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/BallCarrier.cs
+++ b/Assets/Scripts/Player/BallCarrier.cs
@@ -118,7 +118,7 @@ public class BallCarrier : MonoBehaviour
             Gradient grad = new Gradient();
             grad.SetKeys(
                 new GradientColorKey[] {
-                    new GradientColorKey(player.Team.TeamColor, 0.0f)
+                    new GradientColorKey(player.Team != null ? player.Team.TeamColor : GameManager.Settings.NeutralColor, 0.0f)
                 },
                 new GradientAlphaKey[] {
                     new GradientAlphaKey(1.0f,  0.0f),

--- a/Assets/Scripts/Player/PlayerDashBehavior.cs
+++ b/Assets/Scripts/Player/PlayerDashBehavior.cs
@@ -239,13 +239,7 @@ public class PlayerDashBehavior : MonoBehaviour
         int layerMask = LayerMask.GetMask(stopDashOnCollisionWith);
         if (layerMask == (layerMask | 1 << other.layer))
         {
-            // TODO this is a time delay call because the team selection
-            // colliders check for if the player is in the dash state, but
-            // collision moves them out of that state. Dash team selection is
-            // messed up and needs to be fixed/this needs to be removed, but
-            // required until then.
-            this.TimeDelayCall(() => stateManager.TransitionToState(
-                                    State.NormalMovement), 0.1f);
+            stateManager.TransitionToState(State.NormalMovement);
         }
         else
         {

--- a/Assets/Scripts/Player/PlayerDashBehavior.cs
+++ b/Assets/Scripts/Player/PlayerDashBehavior.cs
@@ -239,9 +239,13 @@ public class PlayerDashBehavior : MonoBehaviour
         int layerMask = LayerMask.GetMask(stopDashOnCollisionWith);
         if (layerMask == (layerMask | 1 << other.layer))
         {
-            // TODO dkonik: We used to have a TimeDelayCall here...I'm not sure why
-            // but make sure this works without it
-            stateManager.TransitionToState(State.NormalMovement);
+            // TODO this is a time delay call because the team selection
+            // colliders check for if the player is in the dash state, but
+            // collision moves them out of that state. Dash team selection is
+            // messed up and needs to be fixed/this needs to be removed, but
+            // required until then.
+            this.TimeDelayCall(() => stateManager.TransitionToState(
+                                    State.NormalMovement), 0.1f);
         }
         else
         {

--- a/Assets/Scripts/Utilities/PhysicsTransformView.cs
+++ b/Assets/Scripts/Utilities/PhysicsTransformView.cs
@@ -31,7 +31,6 @@ public class PhysicsTransformView : MonoBehaviour, IPunObservable {
     void FixedUpdate() {
         if (!photonView.IsMine) {
             if (updateState == 1) {
-                Utility.Print("Force transform update", LogLevel.Error);
                 rigidbody.position = networkPosition;
                 rigidbody.rotation = networkRotation;
                 updateState = 2;

--- a/Assets/Scripts/Utilities/Utility.cs
+++ b/Assets/Scripts/Utilities/Utility.cs
@@ -203,6 +203,14 @@ namespace UtilityExtensions
                 return defaultValue;
             }
         }
+
+        public static void Deconstruct<T1, T2>(this KeyValuePair<T1, T2> tuple,
+                                               out T1 key, out T2 value)
+        {
+            key = tuple.Key;
+            value = tuple.Value;
+        }
+
     }
 }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,30 +6,33 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/court-networked-lobby.unity
+    guid: fbd5d415216484587946ebb7d6385fe1
+  - enabled: 1
     path: Assets/Scenes/court.unity
     guid: ca110f435d769440d8595f6864cbc517
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/main-menu.unity
     guid: 725f05ea899f44605801cc8c2edaf12f
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/court-tutorial.unity
     guid: e4951deb6f61d4f6481db6ebf2cd6218
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/court-team-selection.unity
     guid: 89a50e8af325f4979b5ab2404f8e7c3a
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/live-clips/1-shoot-pass-and-score.unity
     guid: 745c9b7a11fb744098c37c2be1380e07
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/live-clips/2-cant-pass-in-null-zone.unity
     guid: e5f4758ff7821481eb85560c6fb01c78
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/live-clips/3-stealing-and-blocking.unity
     guid: 27f9f90a1ac3749a3aafad50235407c8
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/court-sandbox.unity
     guid: 72084d2a7be124d468075e85fa94534e
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/live-clips/4-walls.unity
     guid: 6fb41ef989ecd406d803d158765946e9
   m_configObjects: {}


### PR DESCRIPTION
Adds new scene, court-networked-lobby, which is very similar to the previous court-selection. This is the default loaded scene.

No player objects exist in either this or court by default. Instead new player objects are network-instantiated in the lobby when players join the room. Or rather, after the actor negotiates which player numbers it gets. They're now spawned in at a spawn point given by their player number, without teams. They select teams as before (dashing at the colliders). Team state is synced with the NetworkTeamManager, a new class that interacts with the still-existing TeamManagers (team managers aren't MonoBehaviors).

Once all teams are full, we transition to court, meaning the initial court load is now done while already connected and in a room. Note that we can't follow the DontDestroyOnLoad strategy suggested by Photon without some pretty major refactoring, but luckily we were already set up to just respawn players with the correct teams based on some static dictionaries full of ints.

This mostly works, I think (in that I've tested it with four local builds multiple times), but definitely could break other aspects of the game.

Note: both the NetworkTeamManager and the NetworkPlayerManager really should do check and swap when setting room properties.